### PR TITLE
Named export is more consistent with Probot

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const defaultOptions = {
   cert: findPrivateKey()
 }
 
-module.exports = (app, options = defaultOptions) => {
+module.exports.serverless = (app, options = defaultOptions) => {
   const probot = createProbot(options)
   probot.load(app)
   return probot.server

--- a/index.test.js
+++ b/index.test.js
@@ -1,6 +1,6 @@
 const nock = require('nock')
 const request = require('supertest')
-const serverless = require('./')
+const { serverless } = require('./')
 
 nock.disableNetConnect()
 nock.enableNetConnect('127.0.0.1')


### PR DESCRIPTION
`probot/serverless-now` and `probot/serverless-gcf` both use a named export. This package should be consistent.