### PR TITLE
Support multiple applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,20 @@ module.exports = serverless([statsApp, myApp])
 
 ## API
 
-### `serverless(appFn, [options])`
+### `serverless(appFn[, options])`
 
-Create a new instance of Probot and load the supplied App.
+Create a new instance of Probot and load the supplied App\[s\].
 
-**Options**
+#### Parameters
+
+<!-- prettier-ignore-start -->
+Name | Type | Required | Description
+--- | --- | --- | ---
+appFn | function \| array | true | Single or array of of Probot App functions
+options | [object](#options) | false | Probot config options
+<!-- prettier-ignore-end -->
+
+#### Options
 
 <!-- prettier-ignore-start -->
 Name | Type | Default | Description

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ path in your `now.json` to have a wildcard ending (`"src": "/*"`).
 }
 ```
 
+## Multiple Apps
+
+As mentioned in [using routes](#using-routes), monolithic apps are discouraged.
+That being said, there may be a use case for running multiple Probot Apps
+together (ie logging, stats, etc). For this reason the `serverless` function
+also accepts an array of app functions.
+
+```js
+var { serverless } = require('@chadfawcett/probot-serverless-now')
+const statsApp = require('probot/lib/apps/stats')
+const myApp = require('./')
+
+module.exports = serverless([statsApp, myApp])
+```
+
 ## API
 
 ### `serverless(appFn, [options])`

--- a/index.js
+++ b/index.js
@@ -9,8 +9,9 @@ const defaultOptions = {
   cert: findPrivateKey()
 }
 
-module.exports.serverless = (app, options = defaultOptions) => {
+module.exports.serverless = (apps, options = defaultOptions) => {
   const probot = createProbot(options)
-  probot.load(app)
+  apps = [].concat(apps) //  Coerce to array
+  apps.forEach(a => probot.load(a))
   return probot.server
 }

--- a/index.test.js
+++ b/index.test.js
@@ -5,9 +5,18 @@ const { serverless } = require('./')
 nock.disableNetConnect()
 nock.enableNetConnect('127.0.0.1')
 
+const createApp = name => {
+  const route = `/${name}`
+  return [
+    route,
+    app =>
+      app.route(route).get('/', (_, res) => res.send(`Hello from ${route}`))
+  ]
+}
+
 test('exports regular NodeJS listener usable by servers', () => {
-  const defaultApp = require('probot/lib/apps/default')
-  return request(serverless(defaultApp, { githubToken: 'faketoken' }))
-    .get('/probot')
+  const [route, app] = createApp('app1')
+  return request(serverless(app, { githubToken: 'faketoken' }))
+    .get(route)
     .expect(200)
 })

--- a/index.test.js
+++ b/index.test.js
@@ -20,3 +20,16 @@ test('exports regular NodeJS listener usable by servers', () => {
     .get(route)
     .expect(200)
 })
+
+test('accepts an array of apps', async () => {
+  const [route1, app1] = createApp('app1')
+  const [route2, app2] = createApp('app2')
+  const bot = serverless([app1, app2], { githubToken: 'faketoken' })
+
+  await request(bot)
+    .get(route1)
+    .expect(200, `Hello from ${route1}`)
+  await request(bot)
+    .get(route2)
+    .expect(200, `Hello from ${route2}`)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chadfawcett/probot-serverless-now",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chadfawcett/probot-serverless-now",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A Probot extension to make it easier to run your Probot Apps on Zeit Now v2",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
While the `probot.load` function being used under the hood didn't officially support accepting an array, it did work. So I figured this package might as well support multiple apps but advise against it in the README.

Resolves #6 