### PR TITLE
fix: update function location for probot 10.x.x.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const { createProbot } = require('probot')
-const { findPrivateKey } = require('probot/lib/private-key')
+const { findPrivateKey } = require('probot/lib/helpers/get-private-key')
 
 require('dotenv').config()
 


### PR DESCRIPTION
The location of this file has changed in probot 10.x.x: https://github.com/probot/probot/blob/master/src/helpers/get-private-key.ts

My deployment was failing when switching from 9.x.x to 10.x.x until I applied this patch.